### PR TITLE
master < -issue/9/domain-objects

### DIFF
--- a/src/Pick-em.Lib.Domain/Collections/GameDay.cs
+++ b/src/Pick-em.Lib.Domain/Collections/GameDay.cs
@@ -56,5 +56,15 @@ namespace Pick_em.Lib.Domain
         {
             return this.model.Id;
         }
+
+        /// <summary>
+        /// Adds a reference to the given Season to this GameDay.
+        /// </summary>
+        /// <param name="season">The Season that this GameDay belongs to.</param>
+        public void PutInSeason(Season season)
+        {
+            this.model.Season = season.GetId();
+            season.gameDays.Add(this);
+        }
     }
 }

--- a/src/Pick-em.Lib.Domain/Collections/Season.cs
+++ b/src/Pick-em.Lib.Domain/Collections/Season.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Pick_em.Lib.Models;
+
+namespace Pick_em.Lib.Domain
+{
+    /// <summary>
+    /// Season of a league.
+    /// </summary>
+    public class Season
+    {
+        /// <summary>
+        /// The SeasonModel that represents the Season.
+        /// <summary>
+        private SeasonModel model { get; }
+
+        /// <summary>
+        /// Pointer to the current GameDay of the season.
+        /// </summary>
+        private int gameDayPointer { get; set; }
+
+        /// <summary>
+        /// Determines if the season is currently being played.
+        /// </summary>
+        private SeasonState state { get; set; }
+
+        /// <summary>
+        /// Collection of GameDays that compose the season.
+        /// </summary>
+        internal List<GameDay> gameDays { get; }
+
+        /// <summary>
+        /// Creates a new empty season.
+        /// </summary>
+        public Season(SeasonModel givenModel)
+        {
+            this.model = givenModel;
+            this.gameDays = new List<GameDay>();
+            this.gameDayPointer = 0;
+            this.state = SeasonState.NotStarted;
+        }
+
+        /// <summary>
+        /// Gives the Id of the underlying model.
+        /// </summary>
+        /// <returns>
+        /// Guid that represents the underlying model.
+        /// </returns>
+        internal Guid GetId()
+        {
+            return this.model.Id;
+        }
+
+        /// <summary>
+        /// Advances the season to the next GameDay if it's active.
+        /// </summary>
+        /// <returns>
+        /// True if the current GameDay was advanced.
+        /// </returns>
+        public bool Advance()
+        {
+            switch (this.state)
+            {
+                case SeasonState.NotStarted:
+                    if (this.gameDays.Any())
+                    {
+                        this.state = SeasonState.InProgress;
+                        return true;
+                    }
+                    else
+                        return false;
+                case SeasonState.InProgress:
+                    if (++this.gameDayPointer >= this.gameDays.Count)
+                    {
+                        this.state = SeasonState.Complete;
+                        return true;
+                    }
+                    return true;
+                case SeasonState.Complete:
+                    return false; 
+            }
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Enumeration of a Season.
+    /// </summary>
+    public enum SeasonState { NotStarted, InProgress, Complete }
+}

--- a/test/Pick-em.Lib.Domain.Test/GameDayTest.cs
+++ b/test/Pick-em.Lib.Domain.Test/GameDayTest.cs
@@ -93,5 +93,19 @@ namespace Pick_em.Lib.Domain.Test
 
             Assert.False(result);
         }
+
+        [Fact]
+        public void TestPutInSeason_WhenGiven_ThenUpdated()
+        {
+            Guid expected = Guid.NewGuid();
+            SeasonModel seasonModel = new SeasonModel() {
+                Id = expected
+            };
+            Season season = new Season(seasonModel);
+            
+            this.dut.PutInSeason(season);
+
+            Assert.True(expected.Equals(this.model.Season));
+        }
     }
 }

--- a/test/Pick-em.Lib.Domain.Test/SeasonTest.cs
+++ b/test/Pick-em.Lib.Domain.Test/SeasonTest.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+using Pick_em.Lib.Domain;
+using Pick_em.Lib.Models;
+
+namespace Pick_em.Lib.Domain.Test
+{
+    public class SeasonTest
+    {
+        private Guid uniqueGuid = Guid.NewGuid();
+        private SeasonModel model { get; set; }
+        private Season dut { get; set; }
+
+        public SeasonTest()
+        {
+            this.model = new SeasonModel()
+            { 
+                Id = uniqueGuid
+            };
+            this.dut = new Season(this.model);
+        }
+
+        private Game getPastGame()
+        {
+            GameModel gm = new GameModel();
+            gm.StartTime = DateTime.UtcNow.AddDays(-1);
+            return new Game(gm);
+        }
+
+        private Game getFutureGame()
+        {
+            GameModel gm = new GameModel();
+            gm.StartTime = DateTime.UtcNow.AddDays(1);
+            return new Game(gm);
+        }
+
+        private GameDay getGameDay()
+        {
+            GameDayModel gdModel = new GameDayModel();
+            GameDay gd = new GameDay(gdModel);
+            return gd;
+        }
+
+        private void addMultipleGameDays(int count=3)
+        {
+            GameDay gd;
+            for (int i=0; i<count; i++)
+            {
+                gd = getGameDay();
+                gd.PutInSeason(this.dut);
+            }
+        }
+
+        [Fact]
+        public void TestId_WhenCalled_GivesGuid()
+        {
+            Guid result = this.dut.GetId();
+            Assert.True(result.Equals(uniqueGuid));
+        }
+
+        [Fact]
+        public void TestAdvance_WhenNoGD_ThenFalse()
+        {
+            bool result = this.dut.Advance();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TestAdvance_WhenNotStarted_ThenTrue()
+        {
+            GameDay gd = this.getGameDay();
+            gd.PutInSeason(this.dut);
+
+            bool result = this.dut.Advance();
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void TestAdvance_WhenStarted_ThenAllTrue()
+        {
+            this.addMultipleGameDays(3);
+
+            bool result = this.dut.Advance(); // Start season
+            result &= this.dut.Advance(); // Next GameDay
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void TestAdvance_WhenLastAdvance_ThenAllTrue()
+        {
+            this.addMultipleGameDays(2);
+
+            bool result = this.dut.Advance(); // Start season
+            result &= this.dut.Advance(); // Next GameDay
+            result &= this.dut.Advance(); // Complete Season
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void TestAdvance_WhenAllDone_ThenFalse()
+        {
+            this.addMultipleGameDays(2);
+
+            this.dut.Advance(); // Start season
+            this.dut.Advance(); // Next GameDay
+            this.dut.Advance(); // Complete Season
+            bool result = this.dut.Advance(); // Season already done
+
+            Assert.False(result);
+        }
+    }
+}


### PR DESCRIPTION
Adding `Season` class as part of issue #9. `Season` operates similar to `GameDay` in that it has an internal list of `GameDay`s that is populated by `GameDay` when the reference is added. This is an attempt to provide programmer flexibility while keeping the actual data in the database with a [One-to-many](https://en.wikipedia.org/wiki/One-to-many_(data_model)) relationship. That internal list may change in the future.